### PR TITLE
Fix response body property in GPT for local_setup

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -75,10 +75,10 @@ app.post('/davinci', async (req, res) => {
       presence_penalty: 0.2,
     })
 
-    console.log(response.data.choices[0].text)
+    console.log(response.data.choices[0].message.content)
     // Return response from OpenAI API
     res.status(200).send({
-      bot: response.data.choices[0].text,
+      bot: response.data.choices[0].message.content,
     })
   } catch (error) {
     // Log error and return a generic error message


### PR DESCRIPTION
The response from OpenAI seems changed to `text` -> `message.content`.
In `local_setup` branch, it still remained using previous property.

I'm not sure wether you might cherry-pick or do something for this branch, but hope this PR will help to fix it.