### PR TITLE
feat: improve profanity filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "chatgpt",
       "version": "2.0.0",
       "dependencies": {
-        "bad-words": "^3.0.4",
         "daisyui": "^2.51.6",
         "moment": "^2.29.4",
+        "no-profanity": "^1.4.2",
         "openai": "^3.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4817,22 +4817,6 @@
         "babel-plugin-macros": "^3.1.0",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
-    },
-    "node_modules/bad-words": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
-      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
-      "dependencies": {
-        "badwords-list": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/badwords-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
-      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA=="
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -12500,6 +12484,14 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/no-profanity": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/no-profanity/-/no-profanity-1.4.2.tgz",
+      "integrity": "sha512-mg9E7w0LitTCz6J3T65nZnSzPKN9qc1VHWW0Yn6HUkU/VDWdgLBWoB/fWd3tJcfAk9fuzxAFysYbqACLE0lRjg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -21237,19 +21229,6 @@
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
-    "bad-words": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-3.0.4.tgz",
-      "integrity": "sha512-v/Q9uRPH4+yzDVLL4vR1+S9KoFgOEUl5s4axd6NIAq8SV2mradgi4E8lma/Y0cw1ltVdvyegCQQKffCPRCp8fg==",
-      "requires": {
-        "badwords-list": "^1.0.0"
-      }
-    },
-    "badwords-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-1.0.0.tgz",
-      "integrity": "sha512-oWhaSG67e+HQj3OGHQt2ucP+vAPm1wTbdp2aDHeuh4xlGXBdWwzZ//pfu6swf5gZ8iX0b7JgmSo8BhgybbqszA=="
-    },
     "bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -26695,6 +26674,11 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "no-profanity": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/no-profanity/-/no-profanity-1.4.2.tgz",
+      "integrity": "sha512-mg9E7w0LitTCz6J3T65nZnSzPKN9qc1VHWW0Yn6HUkU/VDWdgLBWoB/fWd3tJcfAk9fuzxAFysYbqACLE0lRjg=="
     },
     "node-forge": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "url": "https://github.com/eyucoder"
   },
   "dependencies": {
-    "bad-words": "^3.0.4",
     "daisyui": "^2.51.6",
     "moment": "^2.29.4",
+    "no-profanity": "^1.4.2",
     "openai": "^3.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/ChatView.js
+++ b/src/components/ChatView.js
@@ -3,7 +3,7 @@ import ChatMessage from './ChatMessage';
 import { ChatContext } from '../context/chatContext';
 import Thinking from './Thinking';
 import { MdSend } from 'react-icons/md';
-import Filter from 'bad-words';
+import { replaceProfanities } from 'no-profanity';
 import { davinci } from '../utils/davinci';
 import { dalle } from '../utils/dalle';
 import Modal from './Modal';
@@ -62,10 +62,7 @@ const ChatView = () => {
       return;
     }
 
-    const filter = new Filter();
-    const cleanPrompt = filter.isProfane(formValue)
-      ? filter.clean(formValue)
-      : formValue;
+    const cleanPrompt = replaceProfanities(formValue)
 
     const newMsg = cleanPrompt;
     const aiModel = selected;


### PR DESCRIPTION
I swapped the profanity filter for a better one I recently developed based on the `bad-words` package. 

The new package has several improvements: 

- 150 times faster due to single regex vs for-loop for all profanities
- more known profanities

I also simplified the code, as the `replaceProfanities` function will simply return original value if there was nothing to replace, and the `isProfane` function calls the same logic, so improves the processing by another factor.